### PR TITLE
Work server streamer correctly

### DIFF
--- a/lib/grpc_kit/session/client_session.rb
+++ b/lib/grpc_kit/session/client_session.rb
@@ -3,6 +3,7 @@
 require 'ds9'
 require 'forwardable'
 require 'grpc_kit/session/stream'
+require 'grpc_kit/session/send_buffer'
 
 module GrpcKit
   module Session
@@ -26,11 +27,12 @@ module GrpcKit
         @stop = false
       end
 
-      def send_request(data, headers)
+      def send_request(headers)
         if @draining
           raise ConnectionClosing, "You can't send new request. becuase this connection will shuting down"
         end
 
+        data = GrpcKit::Session::SendBuffer.new
         stream_id = submit_request(headers, data).to_i
         stream = GrpcKit::Session::Stream.new(stream_id: stream_id, send_data: data)
         stream.stream_id = stream_id

--- a/lib/grpc_kit/session/send_buffer.rb
+++ b/lib/grpc_kit/session/send_buffer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module GrpcKit
-  module Transport
+  module Session
     class SendBuffer
       def initialize
         @buffer = nil

--- a/lib/grpc_kit/session/server_session.rb
+++ b/lib/grpc_kit/session/server_session.rb
@@ -6,7 +6,7 @@ require 'grpc_kit/session/stream'
 require 'grpc_kit/session/drain_controller'
 require 'grpc_kit/stream/server_stream'
 require 'grpc_kit/transport/server_transport'
-require 'grpc_kit/transport/send_buffer'
+require 'grpc_kit/session/send_buffer'
 
 module GrpcKit
   module Session
@@ -198,7 +198,7 @@ module GrpcKit
           raise "#{stream_id} is already existed"
         end
 
-        @streams[stream_id] = GrpcKit::Session::Stream.new(stream_id: stream_id, send_data: GrpcKit::Transport::SendBuffer.new)
+        @streams[stream_id] = GrpcKit::Session::Stream.new(stream_id: stream_id, send_data: GrpcKit::Session::SendBuffer.new)
       end
 
       # nghttp2_session_callbacks_set_on_header_callback

--- a/lib/grpc_kit/session/server_session.rb
+++ b/lib/grpc_kit/session/server_session.rb
@@ -6,6 +6,7 @@ require 'grpc_kit/session/stream'
 require 'grpc_kit/session/drain_controller'
 require 'grpc_kit/stream/server_stream'
 require 'grpc_kit/transport/server_transport'
+require 'grpc_kit/transport/send_buffer'
 
 module GrpcKit
   module Session
@@ -122,7 +123,7 @@ module GrpcKit
 
         stream = @streams[stream_id]
         data = @streams[stream_id].pending_send_data.read(length)
-        if data.empty? && stream.end_write?
+        if data.nil?
           submit_trailer(stream_id, stream.trailer_data)
           # trailer header
           false
@@ -197,7 +198,7 @@ module GrpcKit
           raise "#{stream_id} is already existed"
         end
 
-        @streams[stream_id] = GrpcKit::Session::Stream.new(stream_id: stream_id)
+        @streams[stream_id] = GrpcKit::Session::Stream.new(stream_id: stream_id, send_data: GrpcKit::Transport::SendBuffer.new)
       end
 
       # nghttp2_session_callbacks_set_on_header_callback

--- a/lib/grpc_kit/transport/client_transport.rb
+++ b/lib/grpc_kit/transport/client_transport.rb
@@ -42,7 +42,7 @@ module GrpcKit
       end
 
       def read_data(last: false)
-        unpack(read(last: last))
+        unpack(recv_data(last: last))
       end
 
       def recv_headers
@@ -63,7 +63,7 @@ module GrpcKit
         stream.write(buf, last: last)
       end
 
-      def read(last: false)
+      def recv_data(last: false)
         loop do
           data = @stream.read_recv_data(last: last)
           return data unless data.empty?

--- a/lib/grpc_kit/transport/client_transport.rb
+++ b/lib/grpc_kit/transport/client_transport.rb
@@ -27,15 +27,6 @@ module GrpcKit
         @deferred = false
       end
 
-      def each
-        loop do
-          data = recv
-          return if data.nil?
-
-          yield(data)
-        end
-      end
-
       def write_data(buf, last: false)
         write(@stream.pending_send_data, pack(buf), last: last)
         send_data

--- a/lib/grpc_kit/transport/client_transport.rb
+++ b/lib/grpc_kit/transport/client_transport.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'grpc_kit/transport/packable'
-require 'grpc_kit/transport/send_buffer'
+require 'grpc_kit/session/send_buffer'
 
 module GrpcKit
   module Transport
@@ -16,7 +16,7 @@ module GrpcKit
       end
 
       def start_request(data, header, last: false)
-        @stream = @session.send_request(GrpcKit::Transport::SendBuffer.new, header)
+        @stream = @session.send_request(GrpcKit::Session::SendBuffer.new, header)
         write_data(data, last: last)
       end
 

--- a/lib/grpc_kit/transport/client_transport.rb
+++ b/lib/grpc_kit/transport/client_transport.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'grpc_kit/transport/packable'
-require 'grpc_kit/session/send_buffer'
 
 module GrpcKit
   module Transport
@@ -16,7 +15,7 @@ module GrpcKit
       end
 
       def start_request(data, header, last: false)
-        @stream = @session.send_request(GrpcKit::Session::SendBuffer.new, header)
+        @stream = @session.send_request(header)
         write_data(data, last: last)
       end
 

--- a/lib/grpc_kit/transport/server_transport.rb
+++ b/lib/grpc_kit/transport/server_transport.rb
@@ -25,6 +25,7 @@ module GrpcKit
 
       def start_response(headers)
         @session.submit_response(@stream.stream_id, headers)
+        send_data
       end
 
       def submit_headers(headers)
@@ -33,6 +34,7 @@ module GrpcKit
 
       def write_data(buf, last: false)
         @stream.write_send_data(pack(buf), last: last)
+        send_data
       end
 
       def read_data(last: false)
@@ -41,6 +43,7 @@ module GrpcKit
 
       def write_trailers(trailer)
         @stream.write_trailers_data(trailer)
+        send_data
       end
 
       def end_write
@@ -69,6 +72,14 @@ module GrpcKit
 
           @session.run_once
         end
+      end
+
+      def send_data
+        if @stream.pending_send_data.need_resume?
+          @session.resume_data(@stream.stream_id)
+        end
+
+        @session.run_once
       end
     end
   end

--- a/lib/grpc_kit/transport/server_transport.rb
+++ b/lib/grpc_kit/transport/server_transport.rb
@@ -38,7 +38,7 @@ module GrpcKit
       end
 
       def read_data(last: false)
-        unpack(read(last: last))
+        unpack(recv_data(last: last))
       end
 
       def write_trailers(trailer)
@@ -56,7 +56,7 @@ module GrpcKit
 
       private
 
-      def read(last: false)
+      def recv_data(last: false)
         loop do
           data = @stream.read_recv_data(last: last)
           return data unless data.empty?

--- a/lib/grpc_kit/transport/server_transport.rb
+++ b/lib/grpc_kit/transport/server_transport.rb
@@ -14,15 +14,6 @@ module GrpcKit
         @stream = stream
       end
 
-      def each
-        loop do
-          data = recv
-          return if data.nil?
-
-          yield(data)
-        end
-      end
-
       def start_response(headers)
         @session.submit_response(@stream.stream_id, headers)
         send_data

--- a/spec/grpc_kit/session/send_buffer_spec.rb
+++ b/spec/grpc_kit/session/send_buffer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'grpc_kit/transport/packable'
 
-RSpec.describe GrpcKit::Transport::SendBuffer do
+RSpec.describe GrpcKit::Session::SendBuffer do
   let(:buffer) { described_class.new }
 
   describe '#write' do


### PR DESCRIPTION
From https://github.com/tenderlove/ds9/pull/8, ds9 can return `NGHTTP2_ERR_DEFERRED` in `rb_data_read_callback`(a wrapper method of [nghttp2_data_source_read_callback](https://nghttp2.org/documentation/types.html#c.nghttp2_data_source_read_callback)).
sever_streamer can send each message separately.
