### PR TITLE
Retry trailers only

### DIFF
--- a/lib/grpc_kit/session/server_session.rb
+++ b/lib/grpc_kit/session/server_session.rb
@@ -130,7 +130,9 @@ module GrpcKit
         stream = @streams[stream_id]
         data = @streams[stream_id].pending_send_data.read(length)
         if data.nil?
-          submit_trailer(stream_id, stream.trailer_data)
+           unless stream.trailer_data.empty?
+             submit_trailer(stream_id, stream.trailer_data)
+           end
           # trailer header
           false
         else

--- a/lib/grpc_kit/stream/server_stream.rb
+++ b/lib/grpc_kit/stream/server_stream.rb
@@ -85,7 +85,7 @@ module GrpcKit
       # @param msg [String,nil]
       # @param metadata [Hash<String,String>]
       # @return [void]
-      def send_status(data: nil, status: GrpcKit::StatusCodes::OK, msg: nil, metadata: {})
+      def send_status(data: nil, status: GrpcKit::StatusCodes::OK, msg: 'OK', metadata: {})
         t = build_trailers(status, msg, metadata)
         @transport.write_data(data, last: true) if data
 

--- a/lib/grpc_kit/stream/server_stream.rb
+++ b/lib/grpc_kit/stream/server_stream.rb
@@ -46,7 +46,7 @@ module GrpcKit
         elsif @started
           @transport.write_data(buf)
         else
-          start_response(buf, metadata: initial_metadata)
+          start_response(buf, headers: initial_metadata)
         end
       end
 
@@ -94,7 +94,7 @@ module GrpcKit
           @transport.write_trailers(t)
         elsif data
           # first message with end flag
-          start_response(nil, metadata: t)
+          start_response(nil, headers: t)
         else
           send_headers(trailers: t)
         end
@@ -110,12 +110,12 @@ module GrpcKit
         @started = true
       end
 
-      def start_response(data = nil, metadata: {})
+      def start_response(data = nil, headers: {})
         h = { ':status' => '200', 'content-type' => 'application/grpc' }
         h['accept-encoding'] = 'identity'
 
         @transport.write_data(data) if data
-        @transport.start_response(h.merge(metadata))
+        @transport.start_response(h.merge(headers))
         @started = true
       end
 

--- a/lib/grpc_kit/stream/server_stream.rb
+++ b/lib/grpc_kit/stream/server_stream.rb
@@ -93,8 +93,8 @@ module GrpcKit
         if @started
           @transport.write_trailers(t)
         elsif data
-          @transport.write_trailers(t)
-          start_response
+          # first message with end flag
+          start_response(nil, metadata: t)
         else
           send_headers(trailers: t)
         end

--- a/spec/grpc_kit/stream/server_stream_spec.rb
+++ b/spec/grpc_kit/stream/server_stream_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe GrpcKit::Stream::ServerStream do
             expect(transport.get_start_response[':status']).to eq('200')
             expect(transport.get_write_data).to eq(data)
             expect(transport.get_end_write).to eq(true)
-            expect(transport.get_write_trailers['grpc-status']).to eq(GrpcKit::StatusCodes::OK.to_s)
+            expect(transport.get_start_response['grpc-status']).to eq(GrpcKit::StatusCodes::OK.to_s)
           end
         end
       end
@@ -150,7 +150,7 @@ RSpec.describe GrpcKit::Stream::ServerStream do
           server_stream.send_status(data: data)
           expect(transport.get_write_data).to eq(data)
           expect(transport.get_start_response[':status']).to eq('200')
-          expect(transport.get_write_trailers['grpc-status']).to eq(GrpcKit::StatusCodes::OK)
+          expect(transport.get_start_response['grpc-status']).to eq(GrpcKit::StatusCodes::OK)
           expect(transport.get_submit_headers).to eq(nil)
         end
       end


### PR DESCRIPTION
Same as https://github.com/ganmacs/grpc_kit/pull/2.
~~It may be degraded at some point. I retry to make it send a response as Trailers-Only if possible.~~
it's my mistake. it doesn't work by design of grpc
