### PR TITLE
Concurrency on one TCP connection

### DIFF
--- a/lib/grpc_kit/control_queue.rb
+++ b/lib/grpc_kit/control_queue.rb
@@ -1,0 +1,30 @@
+module GrpcKit
+  class ControlQueue
+    def initialize
+      @event_stream = Queue.new
+    end
+
+    # Be nonblocking
+    def pop
+      if @event_stream.empty?
+        nil
+      else
+        @event_stream.pop(true)
+      end
+    rescue ThreadError => _
+      nil
+    end
+
+    def submit_response(id, headers)
+      @event_stream.push([:submit_response, id, headers])
+    end
+
+    def submit_headers(id, headers)
+      @event_stream.push([:submit_headers, id, headers])
+    end
+
+    def resume_data(id)
+      @event_stream.push([:resume_data, id])
+    end
+  end
+end

--- a/lib/grpc_kit/server.rb
+++ b/lib/grpc_kit/server.rb
@@ -37,13 +37,14 @@ module GrpcKit
     end
 
     # @param conn [TCPSocket]
+    # @param pool [GrpcKit::ThreadPool] Thread pool handling reqeust if need
     # @return [void]
-    def run(conn)
+    def run(conn, pool: default_pool)
       raise 'Stopping server' if @stopping
 
       establish_session(conn) do |s|
         s.submit_settings([])
-        s.start
+        s.start(pool)
       end
     end
 
@@ -112,6 +113,10 @@ module GrpcKit
       ensure
         @mutex.synchronize { @sessions.delete(session) }
       end
+    end
+
+    def default_pool
+      @default_pool ||= GrpcKit::ThreadPool.new
     end
   end
 end

--- a/lib/grpc_kit/server.rb
+++ b/lib/grpc_kit/server.rb
@@ -7,9 +7,13 @@ module GrpcKit
   class Server
     # @param interceptors [Array<GrpcKit::Grpc::ServerInterceptor>] list of interceptors
     # @param shutdown_timeout [Integer] Number of seconds to wait for the server shutdown
-    def initialize(interceptors: [], shutdown_timeout: 30)
+    # @param min_pool_size [Integer] A mininum thread pool size
+    # @param max_pool_size [Integer] A maximum thread pool size
+    def initialize(interceptors: [], shutdown_timeout: 30, min_pool_size: nil, max_pool_size: nil)
       @interceptors = interceptors
       @shutdown_timeout = shutdown_timeout
+      @min_pool_size = min_pool_size || GrpcKit::ThreadPool::DEFAULT_MIN
+      @max_pool_size = max_pool_size || GrpcKit::ThreadPool::DEFAULT_MAX
       @sessions = []
       @rpc_descs = {}
       @mutex = Mutex.new
@@ -37,12 +41,11 @@ module GrpcKit
     end
 
     # @param conn [TCPSocket]
-    # @param pool [GrpcKit::ThreadPool] Thread pool handling reqeust if need
     # @return [void]
-    def run(conn, pool: default_pool)
+    def run(conn)
       raise 'Stopping server' if @stopping
 
-      establish_session(conn, pool) do |s|
+      establish_session(conn) do |s|
         s.submit_settings([])
         s.start
       end
@@ -85,38 +88,41 @@ module GrpcKit
       @mutex.synchronize { @sessions.size }
     end
 
-    # @param path [String] gRPC method path
-    # @param stream [GrpcKit::Streams::ServerStream]
-    # @return [void]
-    def dispatch(path, stream)
+    private
+
+    def dispatch(stream, control_queue)
+      t = GrpcKit::Transport::ServerTransport.new(control_queue, stream)
+      ss = GrpcKit::Stream::ServerStream.new(t)
+      path = stream.headers.path
+
       rpc = @rpc_descs[path]
       unless rpc
         e = GrpcKit::Errors::Unimplemented.new(path)
-        stream.send_status(status: e.code, msg: e.message)
+        ss.send_status(status: e.code, msg: e.message)
         return
       end
 
-      stream.invoke(rpc)
+      ss.invoke(rpc)
     end
 
-    private
+    def thread_pool
+      @thread_pool ||= GrpcKit::ThreadPool.new(min: @min_pool_size, max: @max_pool_size) do |task|
+        dispatch(task[0], task[1])
+      end
+    end
 
     def shutdown_sessions
       @mutex.synchronize { @sessions.each(&:shutdown) }
     end
 
-    def establish_session(conn, pool)
-      session = GrpcKit::Session::ServerSession.new(GrpcKit::Session::IO.new(conn), self, pool)
+    def establish_session(conn)
+      session = GrpcKit::Session::ServerSession.new(GrpcKit::Session::IO.new(conn), thread_pool)
       begin
         @mutex.synchronize { @sessions << session }
         yield(session)
       ensure
         @mutex.synchronize { @sessions.delete(session) }
       end
-    end
-
-    def default_pool
-      @default_pool ||= GrpcKit::ThreadPool.new
     end
   end
 end

--- a/lib/grpc_kit/server.rb
+++ b/lib/grpc_kit/server.rb
@@ -42,9 +42,9 @@ module GrpcKit
     def run(conn, pool: default_pool)
       raise 'Stopping server' if @stopping
 
-      establish_session(conn) do |s|
+      establish_session(conn, pool) do |s|
         s.submit_settings([])
-        s.start(pool)
+        s.start
       end
     end
 
@@ -105,8 +105,8 @@ module GrpcKit
       @mutex.synchronize { @sessions.each(&:shutdown) }
     end
 
-    def establish_session(conn)
-      session = GrpcKit::Session::ServerSession.new(GrpcKit::Session::IO.new(conn), self)
+    def establish_session(conn, pool)
+      session = GrpcKit::Session::ServerSession.new(GrpcKit::Session::IO.new(conn), self, pool)
       begin
         @mutex.synchronize { @sessions << session }
         yield(session)

--- a/lib/grpc_kit/session/server_session.rb
+++ b/lib/grpc_kit/session/server_session.rb
@@ -18,23 +18,17 @@ module GrpcKit
       delegate %i[send_event recv_event] => :@io
 
       # @param io [GrpcKit::Session::IO]
-      # @param dispatcher [GrpcKit::Server]
-      def initialize(io, dispatcher, pool)
+      # @param pool [GrpcKit::ThreadPool] Thread pool handling reqeusts
+      def initialize(io, pool)
         super() # initialize DS9::Session
 
         @io = io
         @streams = {}
         @stop = false
-        @dispatcher = dispatcher
         @inflights = []
         @drain_controller = GrpcKit::Session::DrainController.new
         @control_queue = GrpcKit::ControlQueue.new
-        @pool = pool.register_handler do |task|
-          stream = task[0]
-          t = GrpcKit::Transport::ServerTransport.new(task[1], stream)
-          th = GrpcKit::Stream::ServerStream.new(t)
-          @dispatcher.dispatch(stream.headers.path, th)
-        end
+        @pool = pool
       end
 
       # @return [void]

--- a/lib/grpc_kit/session/server_session.rb
+++ b/lib/grpc_kit/session/server_session.rb
@@ -2,11 +2,13 @@
 
 require 'ds9'
 require 'forwardable'
+require 'grpc_kit/control_queue'
 require 'grpc_kit/session/stream'
 require 'grpc_kit/session/drain_controller'
 require 'grpc_kit/stream/server_stream'
-require 'grpc_kit/transport/server_transport'
 require 'grpc_kit/session/send_buffer'
+require 'grpc_kit/transport/server_transport'
+require 'grpc_kit/thread_pool'
 
 module GrpcKit
   module Session
@@ -26,6 +28,12 @@ module GrpcKit
         @dispatcher = dispatcher
         @inflights = []
         @drain_controller = GrpcKit::Session::DrainController.new
+        @control_queue = GrpcKit::ControlQueue.new
+        @pool = GrpcKit::ThreadPool.new do |stream|
+          t = GrpcKit::Transport::ServerTransport.new(@control_queue, stream)
+          th = GrpcKit::Stream::ServerStream.new(t)
+          @dispatcher.dispatch(stream.headers.path, th)
+        end
       end
 
       # @return [void]
@@ -89,6 +97,7 @@ module GrpcKit
       # @return [void]
       def shutdown
         stop
+        @pool.shutdown
         @io.close
       rescue StandardError => e
         GrpcKit.logger.debug(e)
@@ -101,10 +110,20 @@ module GrpcKit
       end
 
       def invoke
-        while (stream = @inflights.pop)
-          t = GrpcKit::Transport::ServerTransport.new(self, stream)
-          th = GrpcKit::Stream::ServerStream.new(t)
-          @dispatcher.dispatch(stream.headers.path, th)
+        while (event = @control_queue.pop)
+          case event[0]
+          when :submit_response
+            # piggybacked previous invokeing #submit_response?
+            if @streams[event[1]].pending_send_data.empty?
+              next
+            end
+
+            submit_response(event[1], event[2])
+          when :submit_headers
+            submit_headers(event[1], event[2])
+          when :resume_data
+            resume_data(event[1])
+          end
         end
       end
 
@@ -138,7 +157,16 @@ module GrpcKit
         end
       end
 
+      # nghttp2_session_callbacks_set_on_data_chunk_recv_callback
+      def on_data_chunk_recv(stream_id, data, _flags)
+        stream = @streams[stream_id]
+        if stream
+          stream.pending_recv_data.write(data)
+        end
+      end
+
       # nghttp2_session_callbacks_set_on_frame_recv_callback
+      # Note: called after ServerSession#on_data_chunk_recv
       def on_frame_recv(frame)
         GrpcKit.logger.debug("on_frame_recv #{frame}") # Too many call
 
@@ -152,7 +180,7 @@ module GrpcKit
 
           unless stream.inflight
             stream.inflight = true
-            @inflights << stream
+            @pool.schedule(stream)
           end
         when DS9::Frames::Headers
           if frame.end_stream?
@@ -231,14 +259,6 @@ module GrpcKit
           if @streams.empty?
             shutdown
           end
-        end
-      end
-
-      # nghttp2_session_callbacks_set_on_data_chunk_recv_callback
-      def on_data_chunk_recv(stream_id, data, _flags)
-        stream = @streams[stream_id]
-        if stream
-          stream.pending_recv_data.write(data)
         end
       end
     end

--- a/lib/grpc_kit/thread_pool.rb
+++ b/lib/grpc_kit/thread_pool.rb
@@ -7,13 +7,12 @@ module GrpcKit
     DEFAULT_MAX = 20
     DEFAULT_MIN = 5
 
-    def initialize(max = DEFAULT_MAX, min = DEFAULT_MIN, interval: 30, &block)
+    def initialize(max: DEFAULT_MAX, min: DEFAULT_MIN, interval: 30)
       @max_pool_size = max
       @min_pool_size = min
       @shutdown = false
       @tasks = Queue.new
       @auto_trimmer = AutoTrimmer.new(self, interval: interval).tap(&:start!)
-      @block = block
 
       @spawned = 0
       @workers = []
@@ -21,6 +20,11 @@ module GrpcKit
       @waiting = 0
 
       @min_pool_size.times { spawn_thread }
+    end
+
+    def register_handler(&block)
+      @block = block
+      self
     end
 
     # @return [Bool] scheduling is succes or not

--- a/lib/grpc_kit/thread_pool.rb
+++ b/lib/grpc_kit/thread_pool.rb
@@ -12,7 +12,9 @@ module GrpcKit
       @min_pool_size = min
       @shutdown = false
       @tasks = Queue.new
-      @auto_trimmer = AutoTrimmer.new(self, interval: interval).tap(&:start!)
+      unless max == min
+        @auto_trimmer = AutoTrimmer.new(self, interval: interval).tap(&:start!)
+      end
 
       @spawned = 0
       @workers = []
@@ -48,7 +50,7 @@ module GrpcKit
 
     def shutdown
       @shutdown = true
-      @auto_trimmer.stop
+      @auto_trimmer.stop if @auto_trimmer
       @waiting.times { @tasks.push(nil) }
     end
 

--- a/lib/grpc_kit/thread_pool.rb
+++ b/lib/grpc_kit/thread_pool.rb
@@ -7,7 +7,7 @@ module GrpcKit
     DEFAULT_MAX = 20
     DEFAULT_MIN = 5
 
-    def initialize(max: DEFAULT_MAX, min: DEFAULT_MIN, interval: 30)
+    def initialize(max: DEFAULT_MAX, min: DEFAULT_MIN, interval: 30, &block)
       @max_pool_size = max
       @min_pool_size = min
       @shutdown = false
@@ -20,13 +20,9 @@ module GrpcKit
       @workers = []
       @mutex = Mutex.new
       @waiting = 0
+      @block = block
 
       @min_pool_size.times { spawn_thread }
-    end
-
-    def register_handler(&block)
-      @block = block
-      self
     end
 
     # @return [Bool] scheduling is succes or not

--- a/lib/grpc_kit/thread_pool.rb
+++ b/lib/grpc_kit/thread_pool.rb
@@ -7,6 +7,9 @@ module GrpcKit
     DEFAULT_MAX = 20
     DEFAULT_MIN = 5
 
+    # @param min [Integer] A mininum thread pool size
+    # @param max [Integer] A maximum thread pool size
+    # @param interval [Integer] An interval time of calling #trim
     def initialize(max: DEFAULT_MAX, min: DEFAULT_MIN, interval: 30, &block)
       @max_pool_size = max
       @min_pool_size = min
@@ -25,10 +28,10 @@ module GrpcKit
       @min_pool_size.times { spawn_thread }
     end
 
-    # @return [Bool] scheduling is succes or not
+    # @param task [Object] task to schedule
     def schedule(task, &block)
       if task.nil?
-        return true
+        return
       end
 
       if @shutdown
@@ -40,8 +43,6 @@ module GrpcKit
       if @mutex.synchronize { (@waiting < @tasks.size) && (@spawned > @min_pool_size) }
         spawn_thread
       end
-
-      true
     end
 
     def shutdown

--- a/lib/grpc_kit/thread_pool.rb
+++ b/lib/grpc_kit/thread_pool.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'grpc_kit/thread_pool/auto_trimmer'
+
+module GrpcKit
+  class ThreadPool
+    DEFAULT_MAX = 20
+    DEFAULT_MIN = 3
+
+    def initialize(max = DEFAULT_MAX, min = DEFAULT_MIN, interval: 30, &block)
+      @max_pool_size = max
+      @min_pool_size = min
+      @shutdown = false
+      @tasks = Queue.new
+      @auto_trimmer = AutoTrimmer.new(self, interval: interval).tap(&:start!)
+      @block = block
+
+      @spawned = 0
+      @workers = []
+      @mutex = Mutex.new
+
+      @min_pool_size.times { spawn_thread }
+    end
+
+    # @return [Bool] scheduling is succes or not
+    def schedule(task, &block)
+      if task.nil?
+        return true
+      end
+
+      if @shutdown
+        raise "scheduling new task isn't allowed during shutdown"
+      end
+
+      @tasks.push(block || task)
+
+      @mutex.synchronize do
+        if !sleep_worker_exist? && (@spawned < @max_pool_size)
+          spawn_thread
+        end
+      end
+
+      true
+    end
+
+    def shutdown
+      @shutdown = true
+      @auto_trimmer.stop
+      @workers.each(&:kill)
+    end
+
+    def trim(force = false)
+      @mutex.synchronize do
+        if (force || sleep_worker_exist?) && (@spawned > @min_pool_size)
+          GrpcKit.logger.debug("Trim worker! Next worker_size= #{@spawned-1}")
+          @tasks.push(nil)
+        end
+      end
+    end
+
+    private
+
+    # Can be race condition. must use in mutex context
+    def sleep_worker_exist?
+      !!@workers.find { |w| w.status == 'sleep' }
+    end
+
+    def spawn_thread
+      @spawned += 1
+      worker = Thread.new(@spawned) do |i|
+        Thread.current.name = "grpc_kit worker thread #{i}"
+        GrpcKit.logger.debug("#{Thread.current.name} started")
+
+        loop do
+          if @shutdown
+            break
+          end
+
+          task = @tasks.pop
+          if task.nil?
+            break
+          end
+
+          begin
+            @block.call(task)
+          rescue Exception => e # rubocop:disable Lint/RescueException
+            GrpcKit.logger.error("An error occured on top level in worker #{Thread.current.name}: #{e.message} (#{e.class})\n #{Thread.current.backtrace.join("\n")}")
+          end
+        end
+
+        GrpcKit.logger.debug("worker thread #{Thread.current.name} is stopping")
+        @mutex.synchronize do
+          @spawned -= 1
+          @workers.delete(worker)
+        end
+      end
+
+      @workers.push(worker)
+    end
+  end
+end

--- a/lib/grpc_kit/thread_pool/auto_trimmer.rb
+++ b/lib/grpc_kit/thread_pool/auto_trimmer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module GrpcKit
+  class ThreadPool
+    class AutoTrimmer
+      def initialize(pool, interval: 30)
+        @pool = pool
+        @interval = interval
+        @running = false
+      end
+
+      def start!
+        @running = true
+        @thread = Thread.new do
+          loop do
+            unless @running
+              GrpcKit.logger.debug('Stop AutoTrimer')
+              break
+            end
+            @pool.trim
+            sleep @interval
+          end
+        end
+      end
+
+      def stop
+        @running = false
+        @thread.wakeup
+      end
+    end
+  end
+end

--- a/lib/grpc_kit/transport/server_transport.rb
+++ b/lib/grpc_kit/transport/server_transport.rb
@@ -7,23 +7,23 @@ module GrpcKit
     class ServerTransport
       include GrpcKit::Transport::Packable
 
-      # @param session [GrpcKit::Session::ServerSession]
+      # @param session [GrpcKit::ControlQueue]
       # @param stream [GrpcKit::Session::Stream]
-      def initialize(session, stream)
-        @session = session
+      def initialize(control_queue, stream)
+        @control_queue = control_queue
         @stream = stream
       end
 
       # @param headers [Hash<String, String>]
       # @return [void]
       def start_response(headers)
-        @session.submit_response(@stream.stream_id, headers)
+        @control_queue.submit_response(@stream.stream_id, headers)
       end
 
       # @param headers [Hash<String, String>]
       # @return [void]
       def submit_headers(headers)
-        @session.submit_headers(@stream.stream_id, headers)
+        @control_queue.submit_headers(@stream.stream_id, headers)
       end
 
       # @param buf [String]

--- a/spec/grpc_kit/control_queue_spec.rb
+++ b/spec/grpc_kit/control_queue_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'grpc_kit/control_queue'
+
+RSpec.describe GrpcKit::ControlQueue do
+  let(:queue) do
+    described_class.new
+  end
+
+  describe '#pop' do
+    context 'when queue is empty' do
+      it { expect(queue.pop).to eq(nil) }
+    end
+
+    context 'when queue is not empty' do
+      before do
+        queue.resume_data('id')
+      end
+
+      it { expect(queue.pop).to eq([:resume_data, 'id']) }
+    end
+  end
+end


### PR DESCRIPTION
The current implementation has concurrency per TCP connections but doesn't have concurrency on one TCP connection. It would be blocked when recevied concurrent requests in one TCP connection.
For instace, grpc_kit has this probrem when using with envoyproxy since envoyproxy acquires a single connection to an upstream host(griffin, which is a gem using grpc_kit) .

ref: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/connection_pooling)