### PR TITLE
Relax version dependencies on protobuf gems

### DIFF
--- a/grpc_kit.gemspec
+++ b/grpc_kit.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'ds9', '>= 1.3.3'
-  spec.add_dependency 'google-protobuf', '~> 3.6.1'
-  spec.add_dependency 'googleapis-common-protos-types', '~> 1.0.2'
+  spec.add_dependency 'google-protobuf', '>= 3.6.1'
+  spec.add_dependency 'googleapis-common-protos-types', '>= 1.0.2'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'grpc-tools', '~> 1.18.0'


### PR DESCRIPTION
google-protobuf 3.7.0.rc.2 is already released.
https://rubygems.org/gems/google-protobuf