### PR TITLE
Enable no_closed_streams

### DIFF
--- a/grpc_kit.gemspec
+++ b/grpc_kit.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'ds9', '>= 1.3.3'
+  spec.add_dependency 'ds9', '>= 1.4.0'
   spec.add_dependency 'google-protobuf', '>= 3.7.0'
   spec.add_dependency 'googleapis-common-protos-types', '>= 1.0.2'
 

--- a/lib/grpc_kit/session/server_session.rb
+++ b/lib/grpc_kit/session/server_session.rb
@@ -16,7 +16,13 @@ module GrpcKit
       # @param io [GrpcKit::Session::IO]
       # @param pool [GrpcKit::RcpDispatcher]
       def initialize(io, dispatcher)
-        super() # initialize DS9::Session
+        opt = DS9::Option.new.tap do |o|
+          # https://github.com/nghttp2/nghttp2/issues/810
+          # grpc_kit doesn't need to retain closed stream.
+          # This would derease the memory usage.
+          o.set_no_closed_streams
+        end
+        super(option: opt) # initialize DS9::Session
 
         @io = io
         @streams = {}


### PR DESCRIPTION
Since grpc_kit doesn't need to retain closed stream

ref:  https://github.com/tenderlove/ds9/pull/15